### PR TITLE
Fixing gmock and cars depenencies

### DIFF
--- a/src/cars/CMakeLists.txt
+++ b/src/cars/CMakeLists.txt
@@ -120,6 +120,7 @@ add_dependencies(cars cars_generate_messages_cpp)
 # )
 target_link_libraries(car ${catkin_LIBRARIES} cars)
 target_link_libraries(simulation ${catkin_LIBRARIES} cars)
+target_link_libraries(cars ${catkin_LIBRARIES})
 
 #############
 ## Install ##
@@ -162,10 +163,6 @@ target_link_libraries(simulation ${catkin_LIBRARIES} cars)
 
 
 if(CATKIN_ENABLE_TESTING)
-
-  # Create a gmock target to be used as a dependency by test programs
-  add_library(gmock IMPORTED STATIC GLOBAL)
-  set_property(TARGET gmock PROPERTY IMPORTED_LOCATION /usr/lib/libgmock.so)
 
   ## Add gtest based cpp test target and link libraries
 	find_package(rostest REQUIRED)


### PR DESCRIPTION
1.  removes `add_library(gmock IMPORTED STATIC GLOBAL)
  set_property(TARGET gmock PROPERTY IMPORTED_LOCATION /usr/lib/libgmock.so)`
  - catkin seems to provides these now
  - Note from [ros-wiki](https://wiki.ros.org/gtest)

> Do not declare a dependency on gtest in your package manifest. The catkin_add_gtest() macro will pull in the necessary flags. 

but seemingly it does not include the gmock library

2.  adds `target_link_libraries(cars ${catkin_LIBRARIES})`
  - fixes then occurring `libcars.so: undefined reference to `ros::` error

